### PR TITLE
Fix changelog extraction stopping at = in text

### DIFF
--- a/gh-release-notes.sh
+++ b/gh-release-notes.sh
@@ -21,7 +21,7 @@ if [[ -z "$1" ]] || [[ -z "$2" ]]; then
 fi
 
 if [[ "$2" == *"wp"* ]]; then
-   CHANGE=$(sed -e '1,/= Changelog =/d' $1 | sed "/$TAG/,/=/!d;//d" | awk 'NF')
+   CHANGE=$(sed -e '1,/= Changelog =/d' $1 | sed "/= $TAG =/,/^= [0-9]/!d;//d" | awk 'NF')
 else
    CHANGE=$(sed "/$TAG/,/$2/!d;//d" $1 | awk 'NF')
 fi


### PR DESCRIPTION
## Summary
- Fixed sed pattern in WordPress changelog extraction that stopped at the first `=` character in changelog text instead of at the next version header
- Changed `/$TAG/,/=/` to `/= $TAG =/,/^= [0-9]/` to match only version header lines (`= X.Y.Z =`)

## Problem
Changelog entries containing `=` in their text (e.g., `` `debug=1` ``, `` `event_type=Activity,Service` ``) caused the sed range to terminate early. For example, mayo 1.8.8 had 8 changelog entries but only 2 appeared in the GitHub Release.

## Test plan
- [ ] Test against a `readme.txt` with `=` characters in changelog entries (e.g., mayo 1.8.8)
- [ ] Verify normal changelogs without `=` still extract correctly
- [ ] Re-run mayo 1.8.8 release workflow after merging to verify full changelog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)